### PR TITLE
Use different types of quotes in nested quotes to avoid syntax error

### DIFF
--- a/tools/model_generator/ara/app/adaptive_application_extractor.py
+++ b/tools/model_generator/ara/app/adaptive_application_extractor.py
@@ -14,7 +14,7 @@ class AdaptiveApplicationExtractor:
         out_json = {}
         out_json["app_name"] = app.name
         out_json["app_id"] = app.id
-        out_json["bin_path"] = f"/srp/opt/{app.name.split(".")[-1]}/bin/{app.name.split(".")[-1]}"
+        out_json["bin_path"] = f"/srp/opt/{app.name.split('.')[-1]}/bin/{app.name.split('.')[-1]}"
         out_json["parms"] = app.parms
         out_json["fg_list"] = app.functional_groups
         return out_json


### PR DESCRIPTION
Fixed #17 
Quotes nested in the same type of quotes can cause syntax error as explained
[here](https://www.geeksforgeeks.org/single-and-double-quotes-python/)