### PR TITLE
Merge pull request #52 from Bukajn/python_fix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,4 @@ test --test_output=all
 coverage --instrument_test_targets --experimental_cc_coverage --combined_report=lcov --instrumentation_filter="[:],-external/[:]" --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main
 
 test:pytest --strategy=TestRunner=standalone
+common --noenable_bzlmod

--- a/install.bzl
+++ b/install.bzl
@@ -10,9 +10,9 @@ def install():
     deps()
     py_repositories()
     python_register_toolchains(
-        name = "python_3_11",
+        name = "python_3_12",
+        ignore_root_user_error = True,
         # Available versions are listed in @rules_python//python:versions.bzl.
         # We recommend using the same version your team is already standardized on.
-        python_version = "3.11",
+        python_version = "3.12",
     )
-    boost_deps()


### PR DESCRIPTION
Update python and disabled bzlmod

Problem
Bazel nie korzysta z pythona skonfigurowanego w WORKSPACE, lecz z globalnego Opis
Bazel nie widział toolchainów związanych z pythonem. Okazało się, że nie są one ustawione. Wynika to z faktu, że @rules_python nie potrafi ich rejestrować, gdy bzlmod jest włączony (bazel-contrib/rules_python#1675). W tym celu wyłączyłem zupełnie bzlmod. Dodatkowo podwyższyłem wersję pythona do takiej, która współgra z projektem.

Reviewed-by: Bartosz Śnieg